### PR TITLE
Disable SELinux if not enforcing it

### DIFF
--- a/manifests/redhat7/cis_1_6_1_2.pp
+++ b/manifests/redhat7/cis_1_6_1_2.pp
@@ -20,7 +20,7 @@ class secure_linux_cis::redhat7::cis_1_6_1_2 (
       multiple => true,
     }
   } else {
-    file_line { 'selinux_enforce':
+    file_line { 'selinux_disable':
       path     => '/etc/selinux/config',
       line     => 'SELINUX=disabled',
       match    => 'SELINUX=',

--- a/manifests/redhat7/cis_1_6_1_2.pp
+++ b/manifests/redhat7/cis_1_6_1_2.pp
@@ -13,10 +13,16 @@ class secure_linux_cis::redhat7::cis_1_6_1_2 (
 ) {
 
   if $enforced {
-
     file_line { 'selinux_enforce':
       path     => '/etc/selinux/config',
       line     => 'SELINUX=enforcing',
+      match    => 'SELINUX=',
+      multiple => true,
+    }
+  } else {
+    file_line { 'selinux_enforce':
+      path     => '/etc/selinux/config',
+      line     => 'SELINUX=disabled',
       match    => 'SELINUX=',
       multiple => true,
     }

--- a/spec/classes/redhat7/cis_1_6_1_2_spec.rb
+++ b/spec/classes/redhat7/cis_1_6_1_2_spec.rb
@@ -14,15 +14,13 @@ describe 'secure_linux_cis::redhat7::cis_1_6_1_2' do
         if option
           it {
             is_expected.to contain_file_line('selinux_enforce')
-            is_expected.not_to contain_file_line('selinux_disable') 
+            is_expected.not_to contain_file_line('selinux_disable')
           }
         else
-          it { 
-            is_expected.not_to contain_file_line('selinux_enforce') 
+          it {
+            is_expected.not_to contain_file_line('selinux_enforce')
             is_expected.to contain_file_line('selinux_disable')
-            
-            }
-          
+          }
         end
       end
     end

--- a/spec/classes/redhat7/cis_1_6_1_2_spec.rb
+++ b/spec/classes/redhat7/cis_1_6_1_2_spec.rb
@@ -14,9 +14,15 @@ describe 'secure_linux_cis::redhat7::cis_1_6_1_2' do
         if option
           it {
             is_expected.to contain_file_line('selinux_enforce')
+            is_expected.not_to contain_file_line('selinux_disable') 
           }
         else
-          it { is_expected.not_to contain_file_line('selinux_enforce') }
+          it { 
+            is_expected.not_to contain_file_line('selinux_enforce') 
+            is_expected.to contain_file_line('selinux_disable')
+            
+            }
+          
         end
       end
     end


### PR DESCRIPTION
- Ensure SELinux is being configured as targeted or disabled based on the hiera
`secure_linux_cis::redhat7::cis_1_6_1_3::enforced: false ` --> `SELINUX=disabled`
vs
`secure_linux_cis::redhat7::cis_1_6_1_3::enforced: true` --> `SELINUX=enforcing`